### PR TITLE
docs: fix README deployment formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,27 +145,31 @@ At minimum, update these values for your real deployment:
 
 Typical production values look like this:
 
+```yaml
 services:
   minio:
     ports:
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:9001:9001"
+      - '127.0.0.1:9000:9000'
+      - '127.0.0.1:9001:9001'
 
   xdrop:
     ports:
-      - "127.0.0.1:8080:80"
+      - '127.0.0.1:8080:80'
     environment:
       S3_PUBLIC_ENDPOINT: https://xdrop.example.com
       ALLOWED_ORIGINS: https://xdrop.example.com
+```
 
-Treat .env.example as the reference list of supported settings. The provided Compose file uses
+Treat `.env.example` as the reference list of supported settings. The provided Compose file uses
 inline environment values, so editing .env.example alone does not change the running stack.
 
 ### 3. Use the published image
 
+```bash
 docker compose up -d
+```
 
-This uses ghcr.io/xixu-me/xdrop:latest (https://ghcr.io/xixu-me/xdrop).
+This uses `ghcr.io/xixu-me/xdrop:latest` (<https://ghcr.io/xixu-me/xdrop>).
 
 This is enough for a working deployment when the published image already matches the frontend
 build-time settings you want.
@@ -178,29 +182,35 @@ Important caveat:
 
 ### 4. Optional: use your own prebuilt image
 
-Set XDROP_IMAGE if you want the server to run a different prebuilt image:
+Set `XDROP_IMAGE` if you want the server to run a different prebuilt image:
 
+```bash
 XDROP_IMAGE=ghcr.io/your-org/xdrop:your-tag docker compose up -d
+```
 
 ### 5. Optional: build your own image
 
-Build your own image when you need custom frontend build-time settings such as VITE_SITE_URL or
-VITE_API_BASE_URL:
+Build your own image when you need custom frontend build-time settings such as `VITE_SITE_URL` or
+`VITE_API_BASE_URL`:
 
+```bash
 git clone https://github.com/xixu-me/xdrop.git
 cd xdrop
 docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+```
 
-Edit the build args in docker-compose.build.yml before you run that command.
+Edit the build args in `docker-compose.build.yml` before you run that command.
 
 Example:
 
+```yaml
 services:
   xdrop:
     build:
       args:
         VITE_SITE_URL: https://xdrop.example.com
         VITE_API_BASE_URL: /api/v1
+```
 
 On low-memory servers, building the image directly on the host may be slow or fail due to memory
 pressure. In that case, build elsewhere, push the image to a registry, and deploy it with
@@ -210,14 +220,18 @@ XDROP_IMAGE.
 
 Example Caddyfile:
 
+```caddyfile
 xdrop.example.com {
   encode gzip zstd
   reverse_proxy 127.0.0.1:8080
 }
+```
 
 Then reload Caddy:
 
+```bash
 systemctl reload caddy
+```
 
 After the stack starts, open https://xdrop.example.com.
 


### PR DESCRIPTION
### Motivation

- Fix Markdown rendering issues in the README deployment section so examples render correctly in rendered views.
- Improve consistency and readability by normalizing inline code formatting for filenames, environment variables, and image references.

### Description

- Wrap the Docker Compose example in a fenced YAML code block and normalize quoting for port mappings in the example.
- Add fenced `bash` code blocks for shell commands and a fenced `caddyfile` block for the Caddyfile snippet so each snippet renders with proper highlighting.
- Normalize inline code formatting for ` .env.example`, `XDROP_IMAGE`, `docker-compose.build.yml`, and the `ghcr.io/xixu-me/xdrop:latest` image reference.

### Testing

- Ran `npx prettier --write README.md` to apply formatting changes, which completed successfully.
- Verified formatting with `npx prettier --check README.md`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdb17b83bc8333a692662a04c011a3)